### PR TITLE
Add current humidity sensor

### DIFF
--- a/custom_components/climate/broadlink.py
+++ b/custom_components/climate/broadlink.py
@@ -7,9 +7,12 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant.core import callback
-from homeassistant.components.climate import (ClimateDevice, PLATFORM_SCHEMA, STATE_OFF, STATE_IDLE, STATE_HEAT, STATE_COOL, STATE_AUTO,
-ATTR_OPERATION_MODE, SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, SUPPORT_FAN_MODE)
-from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, ATTR_TEMPERATURE, CONF_NAME, CONF_HOST, CONF_MAC, CONF_TIMEOUT, CONF_CUSTOMIZE)
+from homeassistant.components.climate import (ClimateDevice, PLATFORM_SCHEMA, STATE_OFF, STATE_IDLE, STATE_HEAT,
+                                              STATE_COOL, STATE_AUTO, ATTR_CURRENT_HUMIDITY,
+                                              ATTR_OPERATION_MODE, SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE,
+                                              SUPPORT_FAN_MODE)
+from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, ATTR_TEMPERATURE, CONF_NAME, CONF_HOST, CONF_MAC,
+                                 CONF_TIMEOUT, CONF_CUSTOMIZE)
 from homeassistant.helpers.event import (async_track_state_change)
 from homeassistant.helpers.restore_state import RestoreEntity
 from configparser import ConfigParser
@@ -27,6 +30,7 @@ CONF_MAX_TEMP = 'max_temp'
 CONF_TARGET_TEMP = 'target_temp'
 CONF_TARGET_TEMP_STEP = 'target_temp_step'
 CONF_TEMP_SENSOR = 'temp_sensor'
+CONF_HUMIDITY_SENSOR = 'humidity_sensor'
 CONF_OPERATIONS = 'operations'
 CONF_FAN_MODES = 'fan_modes'
 CONF_DEFAULT_OPERATION = 'default_operation'
@@ -56,38 +60,41 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_MAC): cv.string,
     vol.Required(CONF_IRCODES_INI): cv.string,
-    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int, 
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     vol.Optional(CONF_MIN_TEMP, default=DEFAULT_MIN_TEMP): vol.Coerce(float),
     vol.Optional(CONF_MAX_TEMP, default=DEFAULT_MAX_TEMP): vol.Coerce(float),
     vol.Optional(CONF_TARGET_TEMP, default=DEFAULT_TARGET_TEMP): vol.Coerce(float),
     vol.Optional(CONF_TARGET_TEMP_STEP, default=DEFAULT_TARGET_TEMP_STEP): vol.Coerce(float),
     vol.Optional(CONF_TEMP_SENSOR): cv.entity_id,
+    vol.Optional(CONF_HUMIDITY_SENSOR): cv.entity_id,
     vol.Optional(CONF_CUSTOMIZE, default={}): CUSTOMIZE_SCHEMA,
     vol.Optional(CONF_DEFAULT_OPERATION, default=DEFAULT_OPERATION): cv.string,
     vol.Optional(CONF_DEFAULT_FAN_MODE, default=DEFAULT_FAN_MODE): cv.string,
     vol.Optional(CONF_DEFAULT_OPERATION_FROM_IDLE): cv.string
 })
 
+
 async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Broadlink IR Climate platform."""
     name = config.get(CONF_NAME)
     ip_addr = config.get(CONF_HOST)
     mac_addr = binascii.unhexlify(config.get(CONF_MAC).encode().replace(b':', b''))
-      
+
     min_temp = config.get(CONF_MIN_TEMP)
     max_temp = config.get(CONF_MAX_TEMP)
     target_temp = config.get(CONF_TARGET_TEMP)
     target_temp_step = config.get(CONF_TARGET_TEMP_STEP)
     temp_sensor_entity_id = config.get(CONF_TEMP_SENSOR)
+    humidity_sensor_entity_id = config.get(CONF_HUMIDITY_SENSOR)
     operation_list = config.get(CONF_CUSTOMIZE).get(CONF_OPERATIONS, []) or DEFAULT_OPERATION_LIST
     fan_list = config.get(CONF_CUSTOMIZE).get(CONF_FAN_MODES, []) or DEFAULT_FAN_MODE_LIST
     default_operation = config.get(CONF_DEFAULT_OPERATION)
     default_fan_mode = config.get(CONF_DEFAULT_FAN_MODE)
-    
+
     default_operation_from_idle = config.get(CONF_DEFAULT_OPERATION_FROM_IDLE)
-    
+
     import broadlink
-    
+
     broadlink_device = broadlink.rm((ip_addr, 80), mac_addr, None)
     broadlink_device.timeout = config.get(CONF_TIMEOUT)
 
@@ -95,30 +102,34 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
         broadlink_device.auth()
     except socket.timeout:
         _LOGGER.error("Failed to connect to Broadlink RM Device")
-    
-    
+
     ircodes_ini_file = config.get(CONF_IRCODES_INI)
-    
+
     if ircodes_ini_file.startswith("/"):
         ircodes_ini_file = ircodes_ini_file[1:]
-        
+
     ircodes_ini_path = hass.config.path(ircodes_ini_file)
-    
+
     if os.path.exists(ircodes_ini_path):
         ircodes_ini = ConfigParser()
         ircodes_ini.read(ircodes_ini_path)
     else:
         _LOGGER.error("The ini file was not found. (" + ircodes_ini_path + ")")
         return
-    
+
     async_add_devices([
-        BroadlinkIRClimate(hass, name, broadlink_device, ircodes_ini, min_temp, max_temp, target_temp, target_temp_step, temp_sensor_entity_id, operation_list, fan_list, default_operation, default_fan_mode, default_operation_from_idle)
+        BroadlinkIRClimate(hass, name, broadlink_device, ircodes_ini, min_temp, max_temp, target_temp, target_temp_step,
+                           temp_sensor_entity_id, humidity_sensor_entity_id, operation_list, fan_list,
+                           default_operation, default_fan_mode, default_operation_from_idle)
     ])
+
 
 class BroadlinkIRClimate(ClimateDevice, RestoreEntity):
 
-    def __init__(self, hass, name, broadlink_device, ircodes_ini, min_temp, max_temp, target_temp, target_temp_step, temp_sensor_entity_id, operation_list, fan_list, default_operation, default_fan_mode, default_operation_from_idle):
-                 
+    def __init__(self, hass, name, broadlink_device, ircodes_ini, min_temp, max_temp, target_temp, target_temp_step,
+                 temp_sensor_entity_id, humidity_sensor_entity_id, operation_list, fan_list,
+                 default_operation, default_fan_mode, default_operation_from_idle):
+
         """Initialize the Broadlink IR Climate device."""
         self.hass = hass
         self._name = name
@@ -128,43 +139,55 @@ class BroadlinkIRClimate(ClimateDevice, RestoreEntity):
         self._target_temperature = target_temp
         self._target_temperature_step = target_temp_step
         self._unit_of_measurement = hass.config.units.temperature_unit
-        
+
         self._current_temperature = 0
         self._temp_sensor_entity_id = temp_sensor_entity_id
 
+        self._current_humidity = 0
+        self._humidity_sensor_entity_id = humidity_sensor_entity_id
+
         self._current_operation = default_operation
         self._current_fan_mode = default_fan_mode
-        
+
         self._operation_list = operation_list
         self._fan_list = fan_list
-        
+
         self._default_operation_from_idle = default_operation_from_idle
-                
+
         self._broadlink_device = broadlink_device
         self._commands_ini = ircodes_ini
-        
+
         if temp_sensor_entity_id:
             async_track_state_change(
                 hass, temp_sensor_entity_id, self._async_temp_sensor_changed)
-                
-            sensor_state = hass.states.get(temp_sensor_entity_id)    
-                
+
+            sensor_state = hass.states.get(temp_sensor_entity_id)
+
             if sensor_state:
                 self._async_update_current_temp(sensor_state)
-    
-    
-    def send_ir(self):     
+
+        if humidity_sensor_entity_id:
+            async_track_state_change(
+                hass, humidity_sensor_entity_id, self._async_humidity_sensor_changed)
+
+            humidity_sensor_state = hass.states.get(humidity_sensor_entity_id)
+
+            if humidity_sensor_state:
+                self._async_update_current_humidity(humidity_sensor_state)
+
+    def send_ir(self):
         section = self._current_operation.lower()
-        
+
         if section == 'off':
             value = 'off_command'
         elif section == 'idle':
             value = 'idle_command'
-        else: 
-            value = self._current_fan_mode.lower() + "_" + '{0:g}'.format(float(self._target_temperature)) if not section == 'off' else 'off_command'
-        
+        else:
+            value = self._current_fan_mode.lower() + "_" + '{0:g}'.format(
+                float(self._target_temperature)) if not section == 'off' else 'off_command'
+
         command = self._commands_ini.get(section, value)
-        
+
         for retry in range(DEFAULT_RETRY):
             try:
                 payload = b64decode(command)
@@ -176,10 +199,9 @@ class BroadlinkIRClimate(ClimateDevice, RestoreEntity):
                 try:
                     self._broadlink_device.auth()
                 except socket.timeout:
-                    if retry == DEFAULT_RETRY-1:
+                    if retry == DEFAULT_RETRY - 1:
                         _LOGGER.error("Failed to send packet to Broadlink RM Device")
-        
-    
+
     async def _async_temp_sensor_changed(self, entity_id, old_state, new_state):
         """Handle temperature changes."""
         if new_state is None:
@@ -187,7 +209,15 @@ class BroadlinkIRClimate(ClimateDevice, RestoreEntity):
 
         self._async_update_current_temp(new_state)
         await self.async_update_ha_state()
-        
+
+    async def _async_humidity_sensor_changed(self, entity_id, old_state, new_state):
+        """Handle humidity changes."""
+        if new_state is None:
+            return
+
+        self._async_update_current_humidity(new_state)
+        await self.async_update_ha_state()
+
     @callback
     def _async_update_current_temp(self, state):
         """Update thermostat with latest state from sensor."""
@@ -199,16 +229,26 @@ class BroadlinkIRClimate(ClimateDevice, RestoreEntity):
                 self._current_temperature = self.hass.config.units.temperature(
                     float(_state), unit)
         except ValueError as ex:
-            _LOGGER.error('Unable to update from sensor: %s', ex)    
+            _LOGGER.error('Unable to update from sensor: %s', ex)
+
+    def _async_update_current_humidity(self, state):
+        """Update thermostat with latest state from humidity sensor."""
+        unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+
+        try:
+            _state = state.state
+            if unit == '%':
+                self._current_humidity = float(_state)
+        except ValueError as ex:
+            _LOGGER.error('Unable to update from sensor: %s', ex)
 
     def represents_float(self, s):
-        try: 
+        try:
             float(s)
             return True
         except ValueError:
-            return False     
+            return False
 
-    
     @property
     def should_poll(self):
         """Return the polling state."""
@@ -228,22 +268,27 @@ class BroadlinkIRClimate(ClimateDevice, RestoreEntity):
     def current_temperature(self):
         """Return the current temperature."""
         return self._current_temperature
-        
+
+    @property
+    def current_humidity(self):
+        """Return the current humidity."""
+        return self._current_humidity
+
     @property
     def min_temp(self):
         """Return the polling state."""
         return self._min_temp
-        
+
     @property
     def max_temp(self):
         """Return the polling state."""
-        return self._max_temp    
-        
+        return self._max_temp
+
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
         return self._target_temperature
-        
+
     @property
     def target_temperature_step(self):
         """Return the supported step of target temperature."""
@@ -268,32 +313,38 @@ class BroadlinkIRClimate(ClimateDevice, RestoreEntity):
     def fan_list(self):
         """Return the list of available fan modes."""
         return self._fan_list
-        
+
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        return SUPPORT_FLAGS        
- 
+        return SUPPORT_FLAGS
+
     def set_temperature(self, **kwargs):
         """Set new target temperatures."""
         if kwargs.get(ATTR_TEMPERATURE) is not None:
             self._target_temperature = kwargs.get(ATTR_TEMPERATURE)
-            
+
             if not (self._current_operation.lower() == 'off' or self._current_operation.lower() == 'idle'):
                 self.send_ir()
             elif self._default_operation_from_idle is not None:
                 self.set_operation_mode(self._default_operation_from_idle)
-                
-                    
+
             self.schedule_update_ha_state()
+
+    def set_humidity(self, **kwargs):
+        """Set new target humidity."""
+        if kwargs.get(ATTR_CURRENT_HUMIDITY) is not None:
+            self._current_humidity = kwargs.get(ATTR_CURRENT_HUMIDITY)
+
+        self.schedule_update_ha_state()
 
     def set_fan_mode(self, fan):
         """Set new target temperature."""
         self._current_fan_mode = fan
-        
+
         if not (self._current_operation.lower() == 'off' or self._current_operation.lower() == 'idle'):
             self.send_ir()
-            
+
         self.schedule_update_ha_state()
 
     def set_operation_mode(self, operation_mode):
@@ -302,14 +353,15 @@ class BroadlinkIRClimate(ClimateDevice, RestoreEntity):
 
         self.send_ir()
         self.schedule_update_ha_state()
-        
+
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
         await super().async_added_to_hass()
-    
+
         last_state = await self.async_get_last_state()
-        
+
         if last_state is not None:
             self._target_temperature = last_state.attributes['temperature']
             self._current_operation = last_state.attributes['operation_mode']
             self._current_fan_mode = last_state.attributes['fan_mode']
+            self._current_humidity = last_state.attributes['current_humidity']


### PR DESCRIPTION
Allows an optional humidity sensor to be associated to the climate device. This allows services such as google assistant to report humidity.

```
  - platform: broadlink
    name: Room Name
    host: 1.1.1.1
    mac: '00:00:00:00:00:00'
    ircodes_ini: 'filename.ini'
    min_temp: 16
    max_temp: 30
    target_temp: 16
    target_temp_step: 1
    temp_sensor: <sensor name>
    humidity_sensor: <sensor name>
```